### PR TITLE
Integrate OpenAI APIs and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # portfolio
-This is a showcase of my coding projects through Codex. 
+
+This is a showcase of my coding projects through Codex.
+
+## Demo Application
+
+`app_demo.py` demonstrates a small reading assessment workflow. Run it from the
+command line:
+
+```bash
+python app_demo.py
+```
+
+The script walks you through a short quiz to estimate reading level, generates a
+story via OpenAI, then asks for an audio file to transcribe and align. It
+requires an `OPENAI_API_KEY` environment variable for story generation and
+online transcription. Whisper will be used locally if installed. After
+alignment the script prints feedback for each word in the transcript.
+
+Run tests and syntax checks with:
+
+```bash
+python -m unittest discover tests -v
+python -m py_compile *.py
+```

--- a/app_demo.py
+++ b/app_demo.py
@@ -1,0 +1,21 @@
+"""Demo application showing a simple reading assessment flow."""
+
+from utils import take_lexile_test, generate_story, transcribe_audio, align_text
+
+
+def main() -> None:
+    level = take_lexile_test()
+    story = generate_story(level)
+    print("\nGenerated Story:\n", story, "\n")
+
+    audio_file = input("Enter path to audio file for transcription: ").strip()
+    transcript = transcribe_audio(audio_file)
+    feedback = align_text(transcript, story)
+
+    print("\nWord Feedback:")
+    for item in feedback:
+        print(f"{item['word']}: {item['status']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+# whisper is optional for audio transcription
+whisper

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import tempfile
+import unittest
+from unittest import mock
+
+import utils
+
+
+class UtilsTest(unittest.TestCase):
+    def test_take_lexile_test(self):
+        with mock.patch('builtins.input', side_effect=['a', 'b', 'a']):
+            level = utils.take_lexile_test()
+        self.assertEqual(level, 500)
+
+    def test_generate_story(self):
+        fake_resp = {'choices': [{'message': {'content': 'A short story'}}]}
+        with mock.patch('openai.ChatCompletion.create', return_value=fake_resp):
+            story = utils.generate_story(500)
+        self.assertEqual(story, 'A short story')
+
+    def test_transcribe_audio(self):
+        fake_resp = {'text': 'hello world'}
+        with mock.patch('openai.Audio.transcribe', return_value=fake_resp):
+            with tempfile.NamedTemporaryFile('wb') as tmp:
+                tmp.write(b'abc')
+                tmp.flush()
+                text = utils.transcribe_audio(tmp.name)
+        self.assertEqual(text, 'hello world')
+
+    def test_align_text(self):
+        feedback = utils.align_text('hello world', 'hello there world')
+        expected = [
+            {'word': 'hello', 'status': 'ok'},
+            {'word': 'world', 'status': 'diff'}
+        ]
+        self.assertEqual(feedback, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,89 @@
+"""Utility functions for the demo application."""
+
+from typing import List, Dict
+import os
+
+import openai
+
+try:
+    import whisper  # type: ignore
+except Exception:  # whisper is optional
+    whisper = None
+
+
+def take_lexile_test() -> int:
+    """Run a simple interactive Lexile-like quiz and return an estimated level."""
+    questions = [
+        ("Which word is opposite of 'big'?", {"a": "tiny", "b": "huge", "c": "large"}, "a"),
+        ("Choose the noun:", {"a": "run", "b": "cat", "c": "quickly"}, "b"),
+        ("Which is a verb?", {"a": "jump", "b": "blue", "c": "tree"}, "a"),
+    ]
+    score = 0
+    for prompt, options, answer in questions:
+        print(prompt)
+        for key, val in options.items():
+            print(f" {key}) {val}")
+        response = input("Your answer: ").strip().lower()
+        if response == answer:
+            score += 1
+    level = 200 + score * 100
+    print(f"Estimated reading level: {level}")
+    return level
+
+
+def generate_story(level: int) -> str:
+    """Generate a short story for a given reading level using OpenAI."""
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    prompt = (
+        "Write a short, age-appropriate story for a child with reading level "
+        f"{level}."
+    )
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You are a helpful story generator."},
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=120,
+        )
+        return resp["choices"][0]["message"]["content"].strip()
+    except Exception as exc:  # fallback to deterministic story on failure
+        print("Story generation failed:", exc)
+        return (
+            f"Once upon a time, at reading level {level}, "
+            "there lived a coder who loved to write programs."
+        )
+
+
+def transcribe_audio(filename: str) -> str:
+    """Transcribe audio from a file using Whisper or OpenAI."""
+    print(f"Transcribing {filename} ...")
+    if whisper is not None:
+        try:
+            model = whisper.load_model("base")
+            result = model.transcribe(filename)
+            return result["text"].strip()
+        except Exception as exc:
+            print("Local Whisper failed:", exc)
+    try:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        with open(filename, "rb") as f:
+            resp = openai.Audio.transcribe("whisper-1", f)
+        return resp["text"].strip()
+    except Exception as exc:
+        print("OpenAI transcription failed:", exc)
+        return "transcription unavailable"
+
+
+def align_text(transcript: str, reference: str) -> List[Dict[str, str]]:
+    """Align a transcript with reference text and provide word feedback."""
+    transcript_words = transcript.split()
+    ref_words = reference.split()
+    feedback = []
+    for idx, word in enumerate(transcript_words):
+        status = "ok"
+        if idx >= len(ref_words) or word.lower() != ref_words[idx].lower():
+            status = "diff"
+        feedback.append({"word": word, "status": status})
+    return feedback


### PR DESCRIPTION
## Summary
- connect `generate_story` and `transcribe_audio` to OpenAI APIs with optional Whisper fallback
- improve text alignment logic
- document new features and testing instructions in README
- add basic unit tests for utility functions

## Testing
- `python -m py_compile *.py`
- `python -m unittest discover tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68443fe697f08326b8b8b36ecaf46aeb